### PR TITLE
Making shorewall_version fact fail gracefully

### DIFF
--- a/lib/facter/shorewall_version.rb
+++ b/lib/facter/shorewall_version.rb
@@ -9,7 +9,7 @@ if File.exists?("/sbin/shorewall")
   end
 end
 require 'facter'
-if File.exists?("/sbin/shorewall")
+if File.exists?("/sbin/shorewall6")
   Facter.add(:shorewall6_version) do
     version = 0
     Facter::Util::Resolution.exec('shorewall6 version').split('.', 3).each do |v|


### PR DESCRIPTION
The shorewall_version fact fails if the shorewall hasn't been installed already. And the module can't install shorewall when the fact fails. This checks for the existence of shorewall and shorewall6 before checking the version.
