### PR TITLE
Fix rather embarassing issue in shorewall::simple

### DIFF
--- a/manifests/simple.pp
+++ b/manifests/simple.pp
@@ -1,12 +1,16 @@
 # ex: si ts=4 sw=4 et
 
 class shorewall::simple (
-    $ipv4         = true,
-    $ipv6         = false,
-    $inet         = 'inet',
-    $ipv4_tunnels = false,
-    $ipv6_tunnels = false,
+    $ipv4           = true,
+    $ipv6           = false,
+    $inet           = 'inet',
+    $ipv4_tunnels   = false,
+    $ipv6_tunnels   = false,
+    $default_policy = 'REJECT',
+    $open_tcp_ports = [ '22' ],
+    $open_udp_ports = [],
 ) {
+    $non_lo_ifaces = delete(split($::interfaces, ','), 'lo')
 
     class { 'shorewall':
         ipv4         => $ipv4,
@@ -16,6 +20,8 @@ class shorewall::simple (
     }
 
     shorewall::zone { $inet: }
+
+    shorewall::simple::iface { $non_lo_ifaces: }
 
     shorewall::policy { "policy-accept-local-to-all":
         priority => '00',
@@ -42,5 +48,17 @@ class shorewall::simple (
         application => 'Ping',
         action      => 'ACCEPT',
         source      => $inet,
+    }
+
+    unless empty($open_tcp_ports) {
+        shorewall::simple::port { $open_tcp_ports:
+            proto  => 'tcp',
+        }
+    }
+
+    unless empty($open_udp_ports) {
+        shorewall::simple::port { $open_udp_ports:
+            proto  => 'udp',
+        }
     }
 }

--- a/manifests/simple.pp
+++ b/manifests/simple.pp
@@ -38,8 +38,9 @@ class shorewall::simple (
         action   => $default_policy,
     }
 
-    shorewall::port {
+    shorewall::port { 'port-ping-accept':
         application => 'Ping',
         action      => 'ACCEPT',
+        source      => $inet,
     }
 }

--- a/manifests/simple/iface.pp
+++ b/manifests/simple/iface.pp
@@ -1,17 +1,21 @@
 # ex: si ts=4 sw=4 et
 
-define iface (
-    $ipv4    = $shorewall::simple::ipv4,
-    $ipv6    = $shorewall::simple::ipv6,
-    $dynamic = false,
-) {
-    shorewall::iface { $name:
-        ipv4    => $ipv4,
-        ipv6    => $ipv6,
-        options => $dynamic ? {
-            true  => [ 'tcpflags', 'nosmurfs', 'routefilter', 'dhcp', 'optional' ],
-            false => [ 'tcpflags', 'nosmurfs', 'routefilter' ],
-        },
-        zone    => $shorewall::simple::inet,
+define shorewall::simple::iface {
+    if $::shorewall::simple::ipv4 {
+        shorewall::iface { "iface-${name}-ipv4":
+            interface => $name,
+            proto     => 'ipv4',
+            options   => [ 'tcpflags', 'nosmurfs', 'routefilter', 'dhcp', 'optional' ],
+            zone      => $::shorewall::simple::inet,
+        }
+    }
+
+    if $::shorewall::simple::ipv6 {
+        shorewall::iface { "iface-${name}-ipv6":
+            interface => $name,
+            proto     => 'ipv6',
+            options   => [ 'tcpflags', 'nosmurfs', 'routefilter', 'dhcp', 'optional' ],
+            zone      => $::shorewall::simple::inet,
+        }
     }
 }

--- a/manifests/simple/port.pp
+++ b/manifests/simple/port.pp
@@ -2,11 +2,10 @@
 
 define shorewall::simple::port (
     $proto,
-    $port,
 ) {
-    shorewall::port { $name:
+    shorewall::port { "port-${name}-proto":
         proto  => $proto,
-        port   => $port,
-        source => $shorewall::simple::inet,
+        port   => $name,
+        source => $::shorewall::simple::inet,
     }
 }


### PR DESCRIPTION
A couple of problems with the shorewall::port declaration at the bottom of the
class. First, no title for the resource. Second, there is a required parameter
that is not given a value.

Thanks to @Kreichi for sending the error! Closes issue #11