### PR TITLE
Addresses https://github.com/inkblot/puppet-shorewall/issues/15

### DIFF
--- a/manifests/blacklist.pp
+++ b/manifests/blacklist.pp
@@ -1,10 +1,13 @@
 # ex: si ts=4 sw=4 et
 
 define shorewall::blacklist (
-    $type         = 'ipv4',
+    $action        = 'DROP',
+    $type          = 'ipv4',
+    $source        = 'all',
     $address       = '',
+    $dest          = '$FW',
     $proto         = '',
-    $port          = '',
+    $port          = [],
     $order         = '50',
 ) {
     validate_re($proto, '^([0-9]+|tcp|udp|-)$')

--- a/templates/blacklist.erb
+++ b/templates/blacklist.erb
@@ -1,1 +1,1 @@
-<%= @address %>     <%= @proto %>    <%= @port.empty? ? '' : " #{@port}" %>
+<%= @address %>     <%= @proto %>    <%= @port.empty? ? '' : " #{Array(@port).join(',')}" %>

--- a/templates/blrules.erb
+++ b/templates/blrules.erb
@@ -1,1 +1,1 @@
-DROP    all:<%= @address %>     all    <%= @proto %>    <%= @port.empty? ? '' : " #{@port}" %>
+<%= @action %>    <%= source %>:<%= @address %>     <%= @dest %>   <%= @proto %>    <%= @port.empty? ? '' : " #{Array(@port).join(',')}" %>


### PR DESCRIPTION
This adds support for whitelisting per http://shorewall.net/blacklisting_support.htm, as well as allowing for actions other than drop.  It also allows setting port range, source, and destination.