### PR TITLE
Use puppet's native version comparison

### DIFF
--- a/lib/facter/shorewall_version.rb
+++ b/lib/facter/shorewall_version.rb
@@ -2,9 +2,7 @@ require 'facter'
 Facter.add(:shorewall_version) do
   version = 0
   if File.exists?("/sbin/shorewall")
-    Facter::Util::Resolution.exec('shorewall version').split('.', 3).each do |v|
-      version = version * 100 + v.to_i
-    end
+    version = Facter::Util::Resolution.exec('shorewall version')
   end
   setcode { version }
 end
@@ -12,9 +10,7 @@ require 'facter'
 Facter.add(:shorewall6_version) do
   version = 0
   if File.exists?("/sbin/shorewall6")
-    Facter::Util::Resolution.exec('shorewall6 version').split('.', 3).each do |v|
-      version = version * 100 + v.to_i
-    end
+    version = Facter::Util::Resolution.exec('shorewall6 version')
   end
   setcode { version }
 end

--- a/manifests/blacklist.pp
+++ b/manifests/blacklist.pp
@@ -13,7 +13,7 @@ define shorewall::blacklist (
     validate_re($proto, '^([0-9]+|tcp|udp|-)$')
 
     if $type != 'ipv6' and $::shorewall::ipv4 {
-        if ($::shorewall_version < 40425) {
+        if versioncmp($::shorewall_version, '4.4.25') < 0 {
             $blacklist_filename = 'blacklist'
         } else {
             $blacklist_filename = 'blrules'
@@ -27,7 +27,7 @@ define shorewall::blacklist (
     }
 
     if $type != 'ipv4' and $::shorewall::ipv6 {
-        if ($::shorewall6_version < 40425) {
+        if versioncmp($::shorewall6_version, '4.4.25') < 0 {
             $blacklist6_filename = 'blacklist'
         } else {
             $blacklist6_filename = 'blrules'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,6 +22,12 @@ class shorewall (
         mode   => '0644',
     }
 
+    if versioncmp($::shorewall_version, '4.6') >= 0 {
+      $header_lead = '?'
+    } else {
+      $header_lead = ''
+    }
+
     if $ipv4 {
         package { 'shorewall':
             ensure => latest,
@@ -37,7 +43,7 @@ class shorewall (
             source => 'puppet:///modules/shorewall/etc/default/shorewall',
         }
 
-        if ($::shorewall_version < '40425') {
+        if versioncmp($::shorewall_version, '4.4.25') < 0 {
             $blacklist_filename = 'blacklist'
         } else {
             $blacklist_filename = 'blrules'
@@ -214,7 +220,7 @@ class shorewall (
             source => 'puppet:///modules/shorewall/etc/default/shorewall6',
         }
 
-        if ($::shorewall6_version < '40425') {
+        if versioncmp($::shorewall6_version, '4.4.25') < 0 {
             $blacklist6_filename = 'blacklist'
         } else {
             $blacklist6_filename = 'blrules'

--- a/templates/rules-section-new.erb
+++ b/templates/rules-section-new.erb
@@ -1,5 +1,1 @@
-<%- if @shorewall_version >= '40600' -%>
-?SECTION NEW
-<%- else -%>
-SECTION NEW
-<%- end -%>
+<%= @header_lead -%>SECTION NEW


### PR DESCRIPTION
Switch to using the native version comparison library versioncmp() in
order to fix issues with version checks on newer puppet versions.

Fixes issue #19

Signed-off-by: Konstantin Ryabitsev <konstantin@linuxfoundation.org>