### PR TITLE
Quickfix for when /sbin/shorewall is not found

### DIFF
--- a/lib/facter/shorewall_version.rb
+++ b/lib/facter/shorewall_version.rb
@@ -1,6 +1,6 @@
 require 'facter'
 Facter.add(:shorewall_version) do
-  version = 0
+  version = '0'
   if File.exists?("/sbin/shorewall")
     version = Facter::Util::Resolution.exec('shorewall version')
   end
@@ -8,7 +8,7 @@ Facter.add(:shorewall_version) do
 end
 require 'facter'
 Facter.add(:shorewall6_version) do
-  version = 0
+  version = '0'
   if File.exists?("/sbin/shorewall6")
     version = Facter::Util::Resolution.exec('shorewall6 version')
   end


### PR DESCRIPTION
Make sure the default version is string, not integer. This bug manifests
itself when there is no shorewall installed yet and results in the same
"integer vs. string comparison" error when attempting to run puppet.

Related to #19 

Signed-off-by: Konstantin Ryabitsev <konstantin@linuxfoundation.org>