### PR TITLE
Allow additional valid port values

### DIFF
--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -15,7 +15,7 @@ define shorewall::rule (
 ) {
     if $application == '' {
         validate_re($proto, '^(([0-9]+|tcp|udp|icmp|-)(?:,|$))+')
-        validate_re($port, ['^[0-9]+$', '^-$', '^[0-9]+:[0-9]+$'])
+        validate_re($port, ['^:?[0-9]+:?$', '^-$', '^[0-9]+[:,][0-9]+$'])
     } else {
         validate_re($application, '^[[:alnum:]]+$')
         validate_re($proto, '^-?$')


### PR DESCRIPTION
Shorewall also allows ports to be listed as:

- 1024: (ports 1024 and above)
- :1024 (ports 1024 and below)
- 22,10022 (ports 22 and 10022)

Tweak validation rules to allow these values.

Signed-off-by: Konstantin Ryabitsev <konstantin@linuxfoundation.org>