### PR TITLE
Add support for shorewall-stoppedrules

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,6 +59,7 @@ class shorewall (
                 "/etc/shorewall/${mangle_filename}",
                 '/etc/shorewall/routestopped',
                 '/etc/shorewall/conntrack',
+                '/etc/shorewall/stoppedrules'
             ]:
             mode   => '0644',
             notify => Service['shorewall'],
@@ -173,6 +174,14 @@ class shorewall (
             source => 'puppet:///modules/shorewall/conntrack_header',
         }
 
+        # ipv4 stoppedrules
+        concat::fragment { 'stoppedrules-preamble':
+          order   => '01',
+          target  => '/etc/shorewall/stoppedrules',
+          content => "# This file is managed by puppet\n# Changes will be lost\n",
+        }
+
+
         if $traffic_control {
             concat { [
                     '/etc/shorewall/tcinterfaces',
@@ -238,6 +247,7 @@ class shorewall (
                 "/etc/shorewall6/${blacklist_filename}",
                 '/etc/shorewall6/routestopped',
                 '/etc/shorewall6/conntrack',
+                '/etc/shorewall6/stoppedrules',
             ]:
             mode   => '0644',
             notify => Service['shorewall6'],
@@ -323,6 +333,14 @@ class shorewall (
             target  => '/etc/shorewall6/conntrack',
             source  => 'puppet:///modules/shorewall/conntrack6_header',
         }
+
+        # ipv6 conntrack
+        concat::fragment { 'stoppedrules6-header':
+          order   => '00',
+          target  => '/etc/shorewall6/stoppedrules',
+          content => "# This file is managed by puppet\n# Changes will be lost\n",
+        }
+
         service { 'shorewall6':
             ensure     => running,
             hasrestart => true,

--- a/manifests/stoppedrule.pp
+++ b/manifests/stoppedrule.pp
@@ -1,0 +1,44 @@
+# ex: si ts=4 sw=4 et
+
+define shorewall::stoppedrule (
+  $action,
+  $source,
+  $dest,
+  $proto         = '',
+  $port          = '',
+  $sport         = '',
+  $ipv4          = $::shorewall::ipv4,
+  $ipv6          = $::shorewall::ipv6,
+  $order         = '50',
+) {
+
+  validate_re($action, ['^ACCEPT$','^NOTRACK$','^DROP$'])
+
+  if $proto != '' {
+    validate_re($proto, '^(([0-9]+|tcp|udp|icmp|-)(?:,|$))+')
+  }
+
+  if $port != '' {
+    validate_re($port, ['^:?[0-9]+:?$', '^-$', '^[0-9]+[:,][0-9]+$'])
+  }
+
+  if $sport != '' {
+    validate_re($sport, ['^:?[0-9]+:?$', '^-$', '^[0-9]+[:,][0-9]+$'])
+  }
+
+  if $ipv4 {
+    concat::fragment { "stoppedrule-ipv4-${name}":
+      order   => $order,
+      target  => '/etc/shorewall/stoppedrules',
+      content => template('shorewall/stoppedrule.erb'),
+    }
+  }
+
+  if $ipv6 {
+    concat::fragment { "stoppedrule-ipv6-${name}":
+      order   => $order,
+      target  => '/etc/shorewall6/stoppedrules',
+      content => template('shorewall/stoppedrule.erb'),
+    }
+  }
+}

--- a/templates/stoppedrule.erb
+++ b/templates/stoppedrule.erb
@@ -1,0 +1,1 @@
+<%= @action %> <%= @source %> <%= @dest %><%= @proto.empty? ? '' : " #{@proto}" %><%= @port.empty? ? '' : " #{@port}" %><%= @sport.empty? ? '' : " #{@sport}" %>


### PR DESCRIPTION
routestopped file is deprecated in favor of the shorewall-stoppedrules

Signed-off-by: Anton Baranov <abaranov@linuxfoundation.org>