### PR TITLE
add missing /etc/shorewall6/hosts file definition

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -254,6 +254,7 @@ class shorewall (
                 '/etc/shorewall6/policy',
                 '/etc/shorewall6/rules',
                 "/etc/shorewall6/${blacklist_filename}",
+                '/etc/shorewall6/hosts',
                 '/etc/shorewall6/routestopped',
                 '/etc/shorewall6/conntrack',
                 '/etc/shorewall6/stoppedrules',


### PR DESCRIPTION
If missing concat will not place the fragments of shorewall:host

Example warning on client side:
Warning: /Stage[main]/Role::Mysqlserver/Shorewall::Host[web6]/Concat::Fragment[shorewall-host-ipv6-web6]/Concat_fragment[shorewall-host-ipv6-web6]: Target Concat_file with path of /etc/shorewall6/hosts not found in the catalog